### PR TITLE
Jo container style fix

### DIFF
--- a/packages/npm/src/index.tsx
+++ b/packages/npm/src/index.tsx
@@ -99,7 +99,7 @@ const Skeleton: React.FC<ISkeletonProps> = ({
     opacity: opacity.value,
   }));
 
-    const innerContainer = useMemo(() => [containerStyle, hasFadeIn && animatedStyle], [hasFadeIn, containerStyle]);
+    const innerContainer = useMemo(() => [containerStyle, hasFadeIn && animatedStyle], [hasFadeIn, containerStyle, animatedStyle]);
 
   return (
       <View style={styles.root} onLayout={onLayout}>
@@ -127,6 +127,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    alignItems: "center"
+    alignItems: "center",
   }
 });

--- a/packages/npm/src/index.tsx
+++ b/packages/npm/src/index.tsx
@@ -99,8 +99,10 @@ const Skeleton: React.FC<ISkeletonProps> = ({
     opacity: opacity.value,
   }));
 
+    const innerContainer = useMemo(() => [containerStyle, hasFadeIn && animatedStyle], [hasFadeIn, containerStyle]);
+
   return (
-    <View style={containerStyle} onLayout={onLayout}>
+      <View style={styles.root} onLayout={onLayout}>
       {isLoading ? (
         getBones({
           bonesLayout: layout,
@@ -108,7 +110,7 @@ const Skeleton: React.FC<ISkeletonProps> = ({
           generalStyles,
         })
       ) : (
-        <Animated.View style={hasFadeIn ? animatedStyle : {}}>
+        <Animated.View style={innerContainer}>
           {children}
         </Animated.View>
       )}
@@ -119,9 +121,12 @@ const Skeleton: React.FC<ISkeletonProps> = ({
 export default memo(Skeleton);
 
 const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
   container: {
-    alignItems: "center",
     flex: 1,
     justifyContent: "center",
-  },
+    alignItems: "center"
+  }
 });


### PR DESCRIPTION
This MR implements https://github.com/marcuzgabriel/react-native-reanimated-skeleton/issues/11 as there has been issues of diaplaying children especially when the children is a scrollview component.

This MR allows `innerContainer` to be used to style the the inner `Animated.View` rather than the wrapper `View`